### PR TITLE
[update] load asset container blueprint fields once via AssetContainerBlueprintFound event

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -51,7 +51,6 @@ class ServiceProvider extends AddonServiceProvider
             ->bootAddonViews()
             ->bootPermissions()
             ->bootAddonNav()
-            ->bootAssetContainerBlueprints()
             ->bootPostInstall()
             ->publishAssets();
     }
@@ -107,16 +106,6 @@ class ServiceProvider extends AddonServiceProvider
                 '--tag' => 'statamic-cloudinary-config',
             ]);
         });
-
-        return $this;
-    }
-
-    protected function bootAssetContainerBlueprints(): self
-    {
-        foreach (config('statamic.cloudinary.asset_container_mappings', []) as $mapping) {
-            $blueprint = Blueprint::find('assets/' . $mapping['asset_container']);
-            (new AssetContainerBlueprint($blueprint))->setupFields();
-        }
 
         return $this;
     }


### PR DESCRIPTION
If your app doesn't have its own asset container blueprint .yaml file, loading these custom fields at boot won't work.

Instead you have to wait until AssetContainerBlueprintFound event is fired. At this point a virtual blueprint is created with defaults.

Using Blink here to ensure that we only load the custom fields only once per request.