### PR TITLE
Adds 'cloudinary_url' field to content api and GraphQL

### DIFF
--- a/src/GraphQL/FieldManager.php
+++ b/src/GraphQL/FieldManager.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace DoeAnderson\StatamicCloudinary\GraphQL;
+
+use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
+use Statamic\Assets\Asset;
+use Statamic\Facades\GraphQL;
+
+class FieldManager
+{
+    /**
+     * Register custom GraphQL fields.
+     */
+    public function registerCustomFields(): void
+    {
+        $this->cloudinaryUrl();
+    }
+
+    /**
+     * Register 'cloudinary_url' field.
+     *
+     * @return $this
+     */
+    protected function cloudinaryUrl(): self
+    {
+        GraphQL::addField('AssetInterface', 'cloudinary_url', function () {
+            return [
+                'type' => GraphQL::string(),
+                'args' => [],
+                'resolve' => function (Asset $asset, $args) {
+                    $cloudinaryPublicId = $asset->get('cloudinary_public_id');
+                    if (empty($cloudinaryPublicId)) {
+                        return null;
+                    }
+
+                    $image = Cloudinary::getImage($cloudinaryPublicId);
+                    return (string) $image->toUrl();
+                }
+            ];
+        });
+
+        return $this;
+    }
+}

--- a/src/Http/Resources/API/AssetResource.php
+++ b/src/Http/Resources/API/AssetResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DoeAnderson\StatamicCloudinary\Http\Resources\API;
+
+use Statamic\Assets\Asset;
+
+/**
+ * @property Asset $resource
+ */
+class AssetResource extends \Statamic\Http\Resources\API\AssetResource
+{
+    public function toArray($request): array
+    {
+        $data = parent::toArray($request);
+
+        $cloudinaryPublicId = $this->resource->get('cloudinary_public_id');
+
+        if (! empty($cloudinaryPublicId)) {
+            $image = \Cloudinary::getImage($cloudinaryPublicId);
+            $data['cloudinary_url'] = (string) $image->toUrl();
+
+            // TODO: Add 'srcset' and 'sizes' values based on plugin config.
+        }
+
+        return $data;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,6 +9,8 @@ use Statamic\Console\Commands\Install;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\Permission;
+use Statamic\Http\Resources\API\AssetResource;
+use Statamic\Http\Resources\API\Resource;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 
@@ -52,6 +54,7 @@ class ServiceProvider extends AddonServiceProvider
             ->bootPermissions()
             ->bootAddonNav()
             ->bootPostInstall()
+            ->bootCustomApiResources()
             ->publishAssets();
     }
 
@@ -66,6 +69,15 @@ class ServiceProvider extends AddonServiceProvider
                 ->can('configure cloudinary')
                 ->icon('settings-horizontal');
         });
+
+        return $this;
+    }
+
+    protected function bootCustomApiResources(): self
+    {
+        Resource::map([
+            \Statamic\Http\Resources\API\AssetResource::class => \DoeAnderson\StatamicCloudinary\Http\Resources\API\AssetResource::class
+        ]);
 
         return $this;
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,11 +3,13 @@
 namespace DoeAnderson\StatamicCloudinary;
 
 use DoeAnderson\StatamicCloudinary\Actions\UploadToCloudinaryAction;
+use DoeAnderson\StatamicCloudinary\GraphQL\FieldManager;
 use DoeAnderson\StatamicCloudinary\Tags\CloudinaryTags;
 use Illuminate\Support\Facades\Artisan;
 use Statamic\Console\Commands\Install;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\CP\Nav;
+use Statamic\Facades\GraphQL;
 use Statamic\Facades\Permission;
 use Statamic\Http\Resources\API\AssetResource;
 use Statamic\Http\Resources\API\Resource;
@@ -55,6 +57,7 @@ class ServiceProvider extends AddonServiceProvider
             ->bootAddonNav()
             ->bootPostInstall()
             ->bootCustomApiResources()
+            ->bootCustomGraphQLFields()
             ->publishAssets();
     }
 
@@ -78,6 +81,13 @@ class ServiceProvider extends AddonServiceProvider
         Resource::map([
             \Statamic\Http\Resources\API\AssetResource::class => \DoeAnderson\StatamicCloudinary\Http\Resources\API\AssetResource::class
         ]);
+
+        return $this;
+    }
+
+    protected function bootCustomGraphQLFields(): self
+    {
+        (new FieldManager())->registerCustomFields();
 
         return $this;
     }

--- a/src/Tags/CloudinaryTags.php
+++ b/src/Tags/CloudinaryTags.php
@@ -20,6 +20,15 @@ class CloudinaryTags extends Tags
 {
     protected static $handle = 'cloudinary';
 
+    /**
+     * These parameters are used by this tag internally and should not be rendered as <img> tag attributes.
+     *
+     * @var string[]
+     */
+    protected $reservedParams = [
+        'asset',
+    ];
+
     public function index()
     {
         return $this->image();
@@ -31,7 +40,7 @@ class CloudinaryTags extends Tags
      */
     public function image()
     {
-        $params = ['asset', 'id'];
+        $params = ['asset'];
 
         $assetId = $this->params->get($params);
         if (empty($assetId)) {
@@ -64,15 +73,31 @@ class CloudinaryTags extends Tags
          */
         $imageTag = new ImageTag($cloudinaryId);
 
-        $this->resize($imageTag);
+        $this
+            ->resize($imageTag)
+            ->setAttributesFromParams($imageTag);
 
         return $imageTag;
     }
 
     /**
+     * @param ImageTag $imageTag
+     */
+    protected function setAttributesFromParams(ImageTag $imageTag)
+    {
+        foreach ($this->params as $paramKey => $paramValue) {
+            if (in_array($paramKey, $this->reservedParams)) {
+                continue;
+            }
+
+            $imageTag->setAttribute($paramKey, $paramValue);
+        }
+    }
+
+    /**
      * @throws TransformationModeNotFoundException
      */
-    protected function resize(ImageTag $imageTag)
+    protected function resize(ImageTag $imageTag): ?self
     {
         $width = $this->params->get('width');
         $height = $this->params->get('height');
@@ -92,5 +117,7 @@ class CloudinaryTags extends Tags
                 $imageTag->$resizeMode($width, $height);
             }
         }
+
+        return $this;
     }
 }


### PR DESCRIPTION
also allows you to set other img tag attributes with {{ cloudinary:image }} antlers tag