### PR TITLE
[update] assets to not use cloudinary_public_id metadata value

### DIFF
--- a/src/GraphQL/FieldManager.php
+++ b/src/GraphQL/FieldManager.php
@@ -3,6 +3,7 @@
 namespace DoeAnderson\StatamicCloudinary\GraphQL;
 
 use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
+use DoeAnderson\StatamicCloudinary\Helpers\CloudinaryHelper;
 use Statamic\Assets\Asset;
 use Statamic\Facades\GraphQL;
 
@@ -29,12 +30,7 @@ class FieldManager
                 'type' => GraphQL::string(),
                 'args' => [],
                 'resolve' => function (Asset $asset, $args) {
-                    $cloudinaryPublicId = $asset->get('cloudinary_public_id');
-                    if (empty($cloudinaryPublicId)) {
-                        return null;
-                    }
-
-                    $image = Cloudinary::getImage($cloudinaryPublicId);
+                    $image = Cloudinary::getImage(CloudinaryHelper::getPublicId($asset));
                     return (string) $image->toUrl();
                 }
             ];
@@ -50,7 +46,7 @@ class FieldManager
                 'type' => GraphQL::string(),
                 'args' => [],
                 'resolve' => function (Asset $asset, $args) {
-                    return $asset->get('cloudinary_public_id');
+                    return CloudinaryHelper::getPublicId($asset);
                 }
             ];
         });

--- a/src/Helpers/CloudinaryHelper.php
+++ b/src/Helpers/CloudinaryHelper.php
@@ -68,25 +68,40 @@ class CloudinaryHelper
     }
 
     /**
+     * Get public id from asset.
+     *
      * @param Asset $asset
      * @return string
      */
     public static function getPublicId(Asset $asset): string
     {
-        return (string) Str::of($asset->path())
-            ->beforeLast('.' . static::getFileExtension($asset))
+        return static::getPublicIdFromPath($asset->path());
+    }
+
+    /**
+     * Get public id from path.
+     *
+     * @param string $path
+     * @return string
+     */
+    public static function getPublicIdFromPath(string $path): string
+    {
+        $string = (string) Str::of($path)
+            ->beforeLast('.' . static::getFileExtension($path))
             ->after('./');
+
+        return strtolower(preg_replace("/[^A-Za-z0-9-()\/_*.!]/",'_',$string));
     }
 
     /**
      * Get asset's file extension.
      *
-     * @param Asset $asset
+     * @param string $asset
      * @return string
      */
-    public static function getFileExtension(Asset $asset): string
+    public static function getFileExtension(string $path): string
     {
-        return pathinfo($asset->path())['extension'];
+        return pathinfo($path)['extension'];
     }
 
     /**
@@ -97,21 +112,7 @@ class CloudinaryHelper
      */
     public static function isAssetRenamed(Asset $asset): bool
     {
-        $assetPublicId = $asset->get('cloudinary_public_id');
-        if (empty($assetPublicId)) {
-            return false;
-        }
-
-        return $assetPublicId !== static::getPublicId($asset);
-    }
-
-    /**
-     * @param Asset $asset
-     * @return bool
-     */
-    public static function hasCloudinaryId(Asset $asset): bool
-    {
-        return ! is_null($asset->get('cloudinary_public_id'));
+        return $asset->getOriginal('path') !== $asset->path();
     }
 
     /**

--- a/src/Http/Resources/API/AssetResource.php
+++ b/src/Http/Resources/API/AssetResource.php
@@ -2,6 +2,8 @@
 
 namespace DoeAnderson\StatamicCloudinary\Http\Resources\API;
 
+use Cloudinary;
+use DoeAnderson\StatamicCloudinary\Helpers\CloudinaryHelper;
 use Statamic\Assets\Asset;
 
 /**
@@ -13,10 +15,10 @@ class AssetResource extends \Statamic\Http\Resources\API\AssetResource
     {
         $data = parent::toArray($request);
 
-        $cloudinaryPublicId = $this->resource->get('cloudinary_public_id');
+        $cloudinaryPublicId = CloudinaryHelper::getPublicId($this->resource);
 
         if (! empty($cloudinaryPublicId)) {
-            $image = \Cloudinary::getImage($cloudinaryPublicId);
+            $image = Cloudinary::getImage($cloudinaryPublicId);
             $data['cloudinary_url'] = (string) $image->toUrl();
 
             // TODO: Add 'srcset' and 'sizes' values based on plugin config.

--- a/src/Jobs/CreateFolderJob.php
+++ b/src/Jobs/CreateFolderJob.php
@@ -4,6 +4,7 @@ namespace DoeAnderson\StatamicCloudinary\Jobs;
 
 use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
 use DoeAnderson\StatamicCloudinary\Helpers\CloudinaryHelper;
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -36,10 +37,18 @@ class CreateFolderJob implements ShouldQueue
         return 30;
     }
 
-    public function handle()
+    /**
+     * @throws Exception
+     */
+    public function handle(): void
     {
-        Cloudinary::admin()->createFolder(
-            CloudinaryHelper::getCloudinaryUploadFolder($this->assetFolder->container()) . '/' . $this->assetFolder->path()
-        );
+        try {
+            Cloudinary::admin()->createFolder(
+                CloudinaryHelper::getCloudinaryUploadFolder($this->assetFolder->container()) . '/' . $this->assetFolder->path()
+            );
+        } catch (Exception $e) {
+            $message = "Cloudinary: {$e->getMessage()}";
+            throw new Exception($message, 0, $e);
+        }
     }
 }

--- a/src/Jobs/DeleteAssetJob.php
+++ b/src/Jobs/DeleteAssetJob.php
@@ -3,6 +3,8 @@
 namespace DoeAnderson\StatamicCloudinary\Jobs;
 
 use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
+use DoeAnderson\StatamicCloudinary\Helpers\CloudinaryHelper;
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -34,13 +36,16 @@ class DeleteAssetJob implements ShouldQueue
         return 30;
     }
 
-    public function handle()
+    /**
+     * @throws Exception
+     */
+    public function handle(): void
     {
-        $publicId = $this->asset->get('cloudinary_public_id');
-        if (is_null($publicId)) {
-            return;
+        try {
+            Cloudinary::destroy(CloudinaryHelper::getPublicId($this->asset));
+        } catch (Exception $e) {
+            $message = "Cloudinary: {$e->getMessage()}";
+            throw new Exception($message, 0, $e);
         }
-
-        Cloudinary::destroy($publicId);
     }
 }

--- a/src/Jobs/DeleteFolderJob.php
+++ b/src/Jobs/DeleteFolderJob.php
@@ -28,7 +28,7 @@ class DeleteFolderJob implements ShouldQueue
     {
         $this->assetFolder = $assetFolder;
     }
-    
+
     /**
      * @return int
      */
@@ -37,7 +37,7 @@ class DeleteFolderJob implements ShouldQueue
         return 30;
     }
 
-    public function handle()
+    public function handle(): void
     {
         $baseFolder = CloudinaryHelper::getCloudinaryUploadFolder($this->assetFolder->container());
         if (! empty($baseFolder)) {

--- a/src/Jobs/UploadAssetJob.php
+++ b/src/Jobs/UploadAssetJob.php
@@ -5,6 +5,7 @@ namespace DoeAnderson\StatamicCloudinary\Jobs;
 use CloudinaryLabs\CloudinaryLaravel\CloudinaryEngine;
 use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
 use DoeAnderson\StatamicCloudinary\Helpers\CloudinaryHelper;
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -39,20 +40,22 @@ class UploadAssetJob implements ShouldQueue
         return 30;
     }
 
-    public function handle()
+    /**
+     * @throws Exception
+     */
+    public function handle(): void
     {
-        $cloudinaryEngine = Cloudinary::upload(
-            $this->asset->resolvedPath(),
-            [
-                'public_id' => CloudinaryHelper::getPublicId($this->asset),
-                'folder' => CloudinaryHelper::getCloudinaryUploadFolder($this->asset->container()),
-            ]
-        );
-        /* @var $cloudinaryEngine CloudinaryEngine */
-
-
-        $this->asset
-            ->set('cloudinary_public_id', $cloudinaryEngine->getResponse()['public_id'])
-            ->save();
+        try {
+            Cloudinary::upload(
+                $this->asset->resolvedPath(),
+                [
+                    'public_id' => CloudinaryHelper::getPublicId($this->asset),
+                    'folder' => CloudinaryHelper::getCloudinaryUploadFolder($this->asset->container()),
+                ]
+            );
+        } catch (Exception $e) {
+            $message = "Cloudinary: {$e->getMessage()}";
+            throw new Exception($message, 0, $e);
+        }
     }
 }

--- a/src/Subscriber.php
+++ b/src/Subscriber.php
@@ -80,16 +80,10 @@ class Subscriber
             return;
         }
 
-        if (! CloudinaryHelper::hasCloudinaryId($event->asset)) {
-            return;
-        }
-
         if (! CloudinaryHelper::isAssetRenamed($event->asset)) {
             return;
         }
 
-        $oldPath = CloudinaryHelper::getPublicId($event->asset) . '.' . CloudinaryHelper::getFileExtension($event->asset);
-
-        dispatch_sync(new RenameAssetJob($event->asset, $oldPath));
+        dispatch_sync(new RenameAssetJob($event->asset));
     }
 }

--- a/src/Tags/CloudinaryTags.php
+++ b/src/Tags/CloudinaryTags.php
@@ -52,11 +52,7 @@ class CloudinaryTags extends Tags
             throw AssetNotFoundException::notExists($assetId);
         }
 
-        if (! CloudinaryHelper::hasCloudinaryId($asset)) {
-            throw AssetNotFoundException::notCloudinary($assetId);
-        }
-
-        return $this->constructImageTag($asset->cloudinary_public_id);
+        return $this->constructImageTag(CloudinaryHelper::getPublicId($asset));
     }
 
     /**


### PR DESCRIPTION
No need to keep a "cloudinary_public_id" metadata value in sync, but we will need to use CloudinaryHelper::getPublicId() to get the public id for an asset.